### PR TITLE
fix: use gpt-4o as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# vision
+# gpt4-v-vision
 
-`vision` is a simple OpenAI CLI and GPTScript Tool for interacting with vision models.
+`gpt4-v-vision` is a simple OpenAI CLI and GPTScript Tool for interacting with vision models.
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ Options:
   --openai-base-url <string>  OpenAI base URL (env: OPENAI_BASE_URL)
   --openai-org-id <string>    OpenAI Org ID to use (env: OPENAI_ORG_ID)
   --max-tokens <number>       Max tokens to use (default: 2048, env: MAX_TOKENS)
-  --model <model>             Model to process images with (choices: "gpt-4-vision-preview", default: "gpt-4-vision-preview", env: MODEL)
+  --model <model>             Model to process images with (choices: "gpt-4o", "gpt-4-turbo", default: "gpt-4o", env: MODEL)
   --detail <detail>           Fidelity to use when processing images (choices: "low", "high", "auto", default: "auto", env: DETAIL)
   -h, --help                  display help for command
 ```

--- a/index.js
+++ b/index.js
@@ -29,8 +29,11 @@ async function main() {
 
   program.addOption(new Option('--model <model>', 'Model to process images with')
     .env('MODEL')
-    .choices(['gpt-4-vision-preview'])
-    .default('gpt-4-vision-preview')
+    .choices([
+      'gpt-4o',
+      'gpt-4-turbo'
+    ])
+    .default('gpt-4o')
   );
 
   program.addOption(new Option('--detail <detail>', 'Fidelity to use when processing images')
@@ -90,6 +93,7 @@ async function resolveImageURL(image) {
       if (mime != 'image/jpeg' && mime != 'image/png') {
         throw new Error('Unsupported mimetype')
       }
+
       const base64 = data.toString('base64')
       return `data:${mime};base64,${base64}`
     default:

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "commander": "^9.0.0",
+    "commander": "^12.1.0",
     "file-type": "^19.0.0",
-    "openai": "^4.28.0"
+    "openai": "^4.52.0"
   },
   "overrides": {
     "whatwg-url": "13.0.0"

--- a/tool.gpt
+++ b/tool.gpt
@@ -3,8 +3,8 @@ Credential: github.com/gptscript-ai/credential as sys.openai with OPENAI_API_KEY
 Description: Analyze a set of images using a given prompt and vision model.
 Args: detail: (optional) Fidelity to process images at. One of ["high", "low", "auto"]. Default is "auto".
 Args: max-tokens: (optional) The maximum number of tokens. Default is 2048.
-Args: model: (optional) The name of the model to use. Default is "gpt-4-vision-preview".
+Args: model: (optional) The name of the model to use. Default is "gpt-4o".
 Args: prompt: (required) The text prompt based on which the GPT model will generate a response.
-Args: images: (required) Space-delimited list of image URIs to analyze. Valid URI protocols are "http" and "https" for remote images, and "file" for local images. Only supports jpeg and png.
+Args: images: (required) Space-delimited list of image URIs to analyze. Valid URIs start with "http://" and "https://" for remote images, and "file://" for paths to local image files. Only supports jpeg and png.
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js "${PROMPT}" ${IMAGES}


### PR DESCRIPTION
`gpt-4-vision-preview` has been deprecated, which causes vision requests
made by `gpt4-v-vision` to fail. To fix this, switch the default model to `gpt4-o`.

Also:
- correct base64 image URI formatting (fixes vision for local files)
- make `gpt-4-turbo` an available model option
- improve consistency of LLM-generated local file path URI args by
  tweaking parameter description
